### PR TITLE
reduce max isotp message size. 

### DIFF
--- a/src/isotp/isotp_types.h
+++ b/src/isotp/isotp_types.h
@@ -10,7 +10,7 @@
 // TODO we want to avoid malloc, and we can't be allocated 4K on the stack for
 // each IsoTpMessage, so for now we're setting an artificial max message size
 // here - for most multi-frame use cases, 256 bytes is plenty.
-#define OUR_MAX_ISO_TP_MESSAGE_SIZE 256
+#define OUR_MAX_ISO_TP_MESSAGE_SIZE 127
 
 /* Private: IsoTp nibble specifics for PCI and Payload.
  */

--- a/tests/test_receive.c
+++ b/tests/test_receive.c
@@ -136,7 +136,7 @@ END_TEST
 
 START_TEST (test_receive_large_multi_frame)
 {
-    const uint8_t data0[CAN_MESSAGE_BYTE_SIZE] = {0x11, 0x01, 0x49, 0x02, 0x01, 0x31, 0x46, 0x4d};
+    const uint8_t data0[CAN_MESSAGE_BYTE_SIZE] = {0x10, 0x80, 0x49, 0x02, 0x01, 0x31, 0x46, 0x4d};
     IsoTpMessage message = isotp_continue_receive(&SHIMS, &RECEIVE_HANDLE, 0x2a, data0, 8);
     //Make sure we don't try to receive messages that are too large and don't send flow control.
     fail_unless(!can_frame_was_sent);


### PR DESCRIPTION
see OpenXC vi-firmware issue #375 https://github.com/openxc/vi-firmware/issues/375.