### PR TITLE
Hide allocations behind an interface

### DIFF
--- a/src/isotp/allocate.h
+++ b/src/isotp/allocate.h
@@ -1,0 +1,13 @@
+#ifndef __ISOTP_ALLOCATE_H__
+#define __ISOTP_ALLOCATE_H__
+
+#include <stdint.h>
+
+/* The implementation of the two functions is platform-specific and is left to
+ * the user. Implementation used for testing is based on stdlib's malloc/free
+ * and can be found in tests/common.c */
+
+uint8_t* allocate (size_t size);
+void free_allocated (uint8_t* data);
+
+#endif // __ISOTP_ALLOCATE_H_

--- a/src/isotp/isotp.h
+++ b/src/isotp/isotp.h
@@ -6,7 +6,6 @@
 #include <isotp/receive.h>
 #include <stdint.h>
 #include <stdbool.h>
-#include <stdio.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/isotp/receive.c
+++ b/src/isotp/receive.c
@@ -1,8 +1,8 @@
 #include <isotp/receive.h>
+#include <isotp/allocate.h>
 #include <isotp/send.h>
 #include <bitfield/bitfield.h>
 #include <string.h>
-#include <stdlib.h>
 
 #define ARBITRATION_ID_OFFSET 0x8
 
@@ -111,7 +111,7 @@ IsoTpMessage isotp_continue_receive(IsoTpShims* shims,
             //messages. That way we don't have to allocate 4k of memory 
             //for each multi-frame response.
             uint8_t* combined_payload = NULL;
-            combined_payload = (uint8_t*)malloc(sizeof(uint8_t)*payload_length);
+            combined_payload = allocate(payload_length);
 
             if(combined_payload == NULL) {
                 shims->log("Unable to allocate memory for multi-frame response.");
@@ -142,12 +142,12 @@ IsoTpMessage isotp_continue_receive(IsoTpShims* shims,
                 handle->received_buffer_size = start_index + remaining_bytes;
 
                 if(handle->received_buffer_size != handle->incoming_message_size){
-                    free(handle->receive_buffer);
+                    free_allocated(handle->receive_buffer);
                     handle->success = false;
                     shims->log("Error capturing all bytes of multi-frame. Freeing memory.");
                 } else {
                     memcpy(message.payload,&handle->receive_buffer[0],handle->incoming_message_size);
-                    free(handle->receive_buffer);
+                    free_allocated(handle->receive_buffer);
                     message.size = handle->incoming_message_size;
                     message.completed = true;
                     shims->log("Successfully captured all of multi-frame. Freeing memory.");

--- a/tests/common.c
+++ b/tests/common.c
@@ -1,4 +1,5 @@
 #include <isotp/isotp.h>
+#include <isotp/allocate.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -89,3 +90,10 @@ void setup() {
     can_frame_was_sent = false;
 }
 
+uint8_t* allocate(size_t size) {
+    return (uint8_t*) malloc((sizeof(uint8_t))* size);
+}
+
+void free_allocated(uint8_t* data) {
+    free(data);
+}


### PR DESCRIPTION
Should make porting to bare-metal environments easier.

Signed-off-by: Anton Gerasimov <anton@advancedtelematic.com>