### PR TITLE
Hide Memory Allocation Behind Interface

### DIFF
--- a/src/isotp/allocate.c
+++ b/src/isotp/allocate.c
@@ -1,0 +1,14 @@
+#include <isotp/allocate.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <stddef.h>
+
+uint8_t* allocate (size_t size)
+{
+    return (uint8_t*) malloc((sizeof(uint8_t))* size);
+}
+
+void free_allocated (uint8_t* data)
+{
+    free(data);
+}

--- a/src/isotp/allocate.h
+++ b/src/isotp/allocate.h
@@ -1,0 +1,22 @@
+#ifndef __ISOTP_ALLOCATE_H__
+#define __ISOTP_ALLOCATE_H__
+
+#include <stdint.h>
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* The implementation of the two functions is platform-specific and is left to
+ * the user. Implementation used for testing is based on stdlib's malloc/free
+ * and can be found in tests/common.c */
+
+uint8_t* allocate (size_t size);
+void free_allocated (uint8_t* data);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // __ISOTP_ALLOCATE_H_

--- a/src/isotp/allocate.h
+++ b/src/isotp/allocate.h
@@ -8,10 +8,6 @@
 extern "C" {
 #endif
 
-/* The implementation of the two functions is platform-specific and is left to
- * the user. Implementation used for testing is based on stdlib's malloc/free
- * and can be found in tests/common.c */
-
 uint8_t* allocate (size_t size);
 void free_allocated (uint8_t* data);
 

--- a/src/isotp/receive.c
+++ b/src/isotp/receive.c
@@ -1,5 +1,6 @@
 #include <isotp/receive.h>
 #include <isotp/send.h>
+#include <isotp/allocate.h>
 #include <bitfield/bitfield.h>
 #include <string.h>
 #include <stdlib.h>
@@ -111,7 +112,7 @@ IsoTpMessage isotp_continue_receive(IsoTpShims* shims,
             //messages. That way we don't have to allocate 4k of memory 
             //for each multi-frame response.
             uint8_t* combined_payload = NULL;
-            combined_payload = (uint8_t*)malloc(sizeof(uint8_t)*payload_length);
+            combined_payload = allocate(payload_length);
 
             if(combined_payload == NULL) {
                 shims->log("Unable to allocate memory for multi-frame response.");
@@ -142,12 +143,12 @@ IsoTpMessage isotp_continue_receive(IsoTpShims* shims,
                 handle->received_buffer_size = start_index + remaining_bytes;
 
                 if(handle->received_buffer_size != handle->incoming_message_size){
-                    free(handle->receive_buffer);
+                    free_allocated(handle->receive_buffer);
                     handle->success = false;
                     shims->log("Error capturing all bytes of multi-frame. Freeing memory.");
                 } else {
                     memcpy(message.payload,&handle->receive_buffer[0],handle->incoming_message_size);
-                    free(handle->receive_buffer);
+                    free_allocated(handle->receive_buffer);
                     message.size = handle->incoming_message_size;
                     message.completed = true;
                     shims->log("Successfully captured all of multi-frame. Freeing memory.");

--- a/tests/test_allocate.c
+++ b/tests/test_allocate.c
@@ -1,0 +1,34 @@
+#include <isotp/allocate.h>
+#include <check.h>
+
+extern void setup();
+
+START_TEST (test_memory_allocation)
+{
+    uint8_t* test_allocation = allocate(4);
+    ck_assert(test_allocation != NULL);
+    free_allocated(test_allocation);
+}
+END_TEST
+
+Suite* testSuite(void) {
+    Suite* s = suite_create("iso15765");
+    TCase *tc_core = tcase_create("core");
+    tcase_add_checked_fixture(tc_core, setup, NULL);
+    tcase_add_test(tc_core, test_memory_allocation);
+    suite_add_tcase(s, tc_core);
+
+    return s;
+}
+
+int main(void) {
+    int numberFailed;
+    Suite* s = testSuite();
+    SRunner *sr = srunner_create(s);
+    // Don't fork so we can actually use gdb
+    srunner_set_fork_status(sr, CK_NOFORK);
+    srunner_run_all(sr, CK_NORMAL);
+    numberFailed = srunner_ntests_failed(sr);
+    srunner_free(sr);
+    return (numberFailed == 0) ? 0 : 1;
+}


### PR DESCRIPTION
### Changes
- This implements the memory allocation methods shown in #8 
- `allocate.h` and `allocate.c` contains the new methods that are used to allocation and freeing memory
- Added test for memory allocation