### PR TITLE
fix type inconsistencies in send API

### DIFF
--- a/src/isotp/send.c
+++ b/src/isotp/send.c
@@ -56,7 +56,7 @@ IsoTpSendHandle isotp_send_multi_frame(IsoTpShims* shims, IsoTpMessage* message,
     return handle;
 }
 
-IsoTpSendHandle isotp_send(IsoTpShims* shims, const uint16_t arbitration_id,
+IsoTpSendHandle isotp_send(IsoTpShims* shims, const uint32_t arbitration_id,
         const uint8_t payload[], uint16_t size,
         IsoTpMessageSentHandler callback) {
     IsoTpMessage message = {
@@ -73,7 +73,7 @@ IsoTpSendHandle isotp_send(IsoTpShims* shims, const uint16_t arbitration_id,
 }
 
 bool isotp_continue_send(IsoTpShims* shims, IsoTpSendHandle* handle,
-        const uint16_t arbitration_id, const uint8_t data[],
+        const uint32_t arbitration_id, const uint8_t data[],
         const uint8_t size) {
     // TODO this will need to be tested when we add multi-frame support,
     // which is when it'll be necessary to pass in CAN messages to SENDING

--- a/src/isotp/send.h
+++ b/src/isotp/send.h
@@ -53,7 +53,7 @@ typedef struct {
  * multi-frame messages. The 'completed' field in the returned IsoTpSendHandle
  * will be true when the message is completely sent.
  */
-IsoTpSendHandle isotp_send(IsoTpShims* shims, const uint16_t arbitration_id,
+IsoTpSendHandle isotp_send(IsoTpShims* shims, const uint32_t arbitration_id,
         const uint8_t payload[], uint16_t size,
         IsoTpMessageSentHandler callback);
 
@@ -76,7 +76,7 @@ IsoTpSendHandle isotp_send(IsoTpShims* shims, const uint16_t arbitration_id,
  *      it was successful.
  */
 bool isotp_continue_send(IsoTpShims* shims, IsoTpSendHandle* handle,
-        const uint16_t arbitration_id, const uint8_t data[],
+        const uint32_t arbitration_id, const uint8_t data[],
         const uint8_t size);
 
 #ifdef __cplusplus

--- a/tests/test_send.c
+++ b/tests/test_send.c
@@ -29,7 +29,7 @@ extern void setup();
 START_TEST (test_send_empty_payload)
 {
     SHIMS.frame_padding = false;
-    uint16_t arbitration_id = 0x2a;
+    uint32_t arbitration_id = 0x2a;
     IsoTpSendHandle handle = isotp_send(&SHIMS, arbitration_id, NULL, 0, message_sent);
     fail_unless(handle.success);
     fail_unless(handle.completed);
@@ -49,7 +49,7 @@ START_TEST (test_send_single_frame)
 {
     SHIMS.frame_padding = false;
     const uint8_t payload[] = {0x12, 0x34};
-    uint16_t arbitration_id = 0x2a;
+    uint32_t arbitration_id = 0x2a;
     isotp_send(&SHIMS, arbitration_id, payload, sizeof(payload), message_sent);
     ck_assert_int_eq(last_message_sent_arb_id, arbitration_id);
     fail_unless(last_message_sent_status);
@@ -70,7 +70,7 @@ START_TEST (test_send_multi_frame)
 {
     const uint8_t payload[] = {0x12, 0x34, 0x56, 0x78, 0x90, 0x01, 0x23,
             0x45, 0x67, 0x89};
-    uint16_t arbitration_id = 0x2a;
+    uint32_t arbitration_id = 0x2a;
     IsoTpSendHandle handle = isotp_send(&SHIMS, arbitration_id, payload, sizeof(payload),
             message_sent);
     fail_unless(handle.completed);


### PR DESCRIPTION
The  type of ```arbitration_id``` parameter in ```isotp_send``` and ```isotp_continue_send``` functions does not match the ```IsoTpMessage``` signature. This lead to CAN identifiers beeing truncated on the bus.