### PR TITLE
Security: Fix buffer overflow in src/isotp/send.c isotp_send_single_frame

### DIFF
--- a/src/isotp/send.c
+++ b/src/isotp/send.c
@@ -19,6 +19,11 @@ IsoTpSendHandle isotp_send_single_frame(IsoTpShims* shims, IsoTpMessage* message
         success: false,
         completed: true
     };
+    /* multi frame message length must greater than 7  */
+    if(message->size > 7) {
+        shims->log("Single frame payload exceeds maximum size (7 bytes)");
+        return handle;
+    }
 
     uint8_t can_data[CAN_MESSAGE_BYTE_SIZE] = {0};
     if(!set_nibble(PCI_NIBBLE_INDEX, PCI_SINGLE, can_data, sizeof(can_data))) {


### PR DESCRIPTION
### Summary
A **critical** buffer overflow vulnerability exists in `isotp_send_single_frame` function with **no size validation whatsoever**. This is **more severe** than the recent Zephyr RTOS CVE, which at least had debug-time assertions.

### Zephyr CVE Reference

Zephyr RTOS had the exact same vulnerability pattern that was recently patched:
[https://nvd.nist.gov/vuln/detail/CVE-2023-3725](https://nvd.nist.gov/vuln/detail/CVE-2023-3725)
[https://github.com/zephyrproject-rtos/zephyr/security/advisories/GHSA-2g3m-p6c7-8rr3](https://github.com/zephyrproject-rtos/zephyr/security/advisories/GHSA-2g3m-p6c7-8rr3)
**Before (vulnerable):**
```c
__ASSERT_NO_MSG(len <= ISOTP_CAN_DL - index);
memcpy(&frame.data[index], data, len);
```
**After (Fixed):**
```c
if (len > ISOTP_CAN_DL - index) {
    LOG_ERR("SF len does not fit DL");
    return -ENOSPC;
}
memcpy(&frame.data[index], data, len);
```


### Affected Code in openxc/isotp-c
**File**: `src/isotp/send.c` 
**Function**:`isotp_send_single_frame`
```c
IsoTpSendHandle isotp_send_single_frame(IsoTpShims* shims, IsoTpMessage* message,
        IsoTpMessageSentHandler callback) {
    IsoTpSendHandle handle = {
        success: false,
        completed: true
    };
    // ...
    /* No size valdation */
    if(message->size > 0) {
        memcpy(&can_data[1], message->payload, message->size);
    }
   // ...
}
```


### Vulnerability Details
1. Debug-only protection
2. Buffer overflow risk


### Impact
1. Memory corruption (Stack/Heap)
2. System crashes


### Recommended Fix
```c
IsoTpSendHandle isotp_send_single_frame(IsoTpShims* shims, IsoTpMessage* message,
        IsoTpMessageSentHandler callback) {
    IsoTpSendHandle handle = {
        success: false,
        completed: true
    };
    /* multi frame message length must greater than 7  */
    if(message->size > 7) {
        shims->log("Single frame payload exceeds maximum size (7 bytes)");
        return handle;
    }
    // ...
    
    if(message->size > 0) {
        memcpy(&can_data[1], message->payload, message->size);
    }
    // ...
}
```
### Priority
**High** - Same pattern that warranted CVE in Zephyr RTOS

### PoC
Due to the complexity of setting up a CAN hardware environment, I haven't tested this vulnerability against a real embedded system.
However, code analysis clearly demonstrates the buffer overflow potential.